### PR TITLE
forward request headers in tool calls

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -665,7 +665,7 @@ func TestExecuteToolCall(t *testing.T) {
 			}
 
 			// --- Execute Function ---
-			httpResp, err := executeToolCall(&tc.params, toolSet, &testCfg) // Use the potentially modified testCfg
+			httpResp, err := executeToolCall(&tc.params, toolSet, &testCfg, nil) // Use the potentially modified testCfg
 
 			// --- Assertions ---
 			if tc.expectError {


### PR DESCRIPTION
## Summary
- pass incoming headers from `httpMethodPostHandler` into `handleToolCallJSONRPC`
- copy those headers into `headerParams` so `executeToolCall` forwards them when invoking the backend API
- adjust tests for new function signatures

## Testing
- `go test ./...` *(fails: fetching modules requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_6852b452ed6c832b9a5c994509dbb244