### PR TITLE
Change error handling for tool call

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -826,13 +826,14 @@ func handleToolCallJSONRPC(connID string, req *jsonRPCRequest, toolSet *mcp.Tool
 			log.Printf("Received response body for tool '%s': %s", params.ToolName, string(bodyBytes))
 			// Check status code for API-level errors
 			if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+				// Put error details into the Content field so MCP clients can access them
+				errText := fmt.Sprintf("Tool '%s' API call failed with status %s: %s", params.ToolName, httpResp.Status, string(bodyBytes))
 				resultPayload = ToolResultPayload{
 					IsError: true,
-					Error: &MCPError{
-						Code:    httpResp.StatusCode,
-						Message: fmt.Sprintf("Tool '%s' API call failed with status %s", params.ToolName, httpResp.Status),
-						Data:    string(bodyBytes), // Include response body in error data
-					},
+					Content: []ToolResultContent{{
+						Type: "text",
+						Text: errText,
+					}},
 					ToolCallID: fmt.Sprintf("%v", req.ID),
 				}
 			} else {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -187,14 +187,13 @@ func TestHttpMethodPostHandler(t *testing.T) {
 			expectedSyncStatus: http.StatusAccepted,
 			expectedSyncBody:   "Request accepted, response will be sent via SSE.\n",
 			checkAsyncResponse: func(t *testing.T, resp jsonRPCResponse) {
-				assert.Equal(t, "call-post-err-1", resp.ID)
-				assert.Nil(t, resp.Error)
-				resultPayload, ok := resp.Result.(ToolResultPayload)
-				require.True(t, ok)
-				assert.True(t, resultPayload.IsError)
-				require.Len(t, resultPayload.Content, 1)
-				assert.Contains(t, resultPayload.Content[0].Text, "operation details for tool 'nonexistent_tool' not found")
-				assert.Nil(t, resultPayload.Error)
+                               assert.Equal(t, "call-post-err-1", resp.ID)
+                               assert.Nil(t, resp.Error)
+                               resultPayload, ok := resp.Result.(ToolResultPayload)
+                               require.True(t, ok)
+                               assert.True(t, resultPayload.IsError)
+                               require.NotNil(t, resultPayload.Error)
+                               assert.Contains(t, resultPayload.Error.Message, "operation details for tool 'nonexistent_tool' not found")
 			},
 		},
 		{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -192,8 +192,9 @@ func TestHttpMethodPostHandler(t *testing.T) {
 				resultPayload, ok := resp.Result.(ToolResultPayload)
 				require.True(t, ok)
 				assert.True(t, resultPayload.IsError)
-				require.NotNil(t, resultPayload.Error)
-				assert.Contains(t, resultPayload.Error.Message, "operation details for tool 'nonexistent_tool' not found")
+				require.Len(t, resultPayload.Content, 1)
+				assert.Contains(t, resultPayload.Content[0].Text, "operation details for tool 'nonexistent_tool' not found")
+				assert.Nil(t, resultPayload.Error)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- return tool call errors inside the `content` field so MCP clients can read them
- update tests accordingly

## Testing
- `go test ./...` *(fails: Forbidden for proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_6855570abba4832ba20b6d8ef412884f